### PR TITLE
Change keywords to comma-seperated list

### DIFF
--- a/library.json
+++ b/library.json
@@ -2,9 +2,7 @@
     "name": "ghostl",
     "version": "1.0.0",
     "description": "Lock-free queue; C++ coroutines; and a nano-sized C++ STL adapter for MCUs like ESP8266/ESP32.",
-    "keywords": [
-        "lock-free; coroutine; stl"
-    ],
+    "keywords": "lock-free, coroutine, stl",
     "repository":
     {
         "type": "git",


### PR DESCRIPTION
https://docs.platformio.org/en/latest/manifests/library-json/fields/keywords.html

In order to fix this error when running `pio pkg pack`
```
ManifestValidationError: Invalid manifest fields: {'keywords': {0: ['Only [a-z0-9+_-. ] chars are allowed']}}.
Please check specification -> https://docs.platformio.org/page/librarymanager/config.html
```